### PR TITLE
Add default to `ParcelsGenerator.add_subjects(p_threshold_value=)` in agreement with documentation

### DIFF
--- a/funROI/analysis/parcels_gen.py
+++ b/funROI/analysis/parcels_gen.py
@@ -75,7 +75,7 @@ class ParcelsGenerator:
         task: str,
         contrasts: List[str],
         p_threshold_type: str,
-        p_threshold_value: float,
+        p_threshold_value: float = 0.05,
         conjunction_type: Optional[str] = "and",
     ):
         """


### PR DESCRIPTION
Documentation says there's a default value (0.05) for `ParcelsGenerator.add_subjects(p_threshold_value=)` but it's not been added. See https://github.com/GT-LIT-Lab/funROI/blob/main/funROI/analysis/parcels_gen.py.